### PR TITLE
Db-setup update

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,19 +109,18 @@ docker-compose up -d server
 docker-compose up dev-server
 
 # start database (sqlite) in background
-docker-compose up -d sqlite-db
+docker-compose up sqlite-db
 
 # shut down all containers
 docker-compose down
 ```
 ## Database
 ```
-# start database (sqlite) in background
-docker-compose up -d sqlite-db
+# initiate database creation with docker
+docker-compose up sqlite-db
 
-The database (bikr.db) is created when the sqlite-db container is initiated. To reach bikr.db from other applications in the same 
-docker network, the containers (both sqlite-db and the connecting part) need to have "./db:/db" as a volume in docker-compose.yml. 
-Once the sqlite-db container is initiated/setup the setup.db.bash is executed and creates a database (bikr.db) as a volume. It 
-overwrites the existing local db/bikr.db file you may already have upon container initialization.
+The database (bikr.db) is created when the sqlite-db container is initiated. Use the path ./db:/db" as a volume in docker-compose.yml
+to add the database in server or dev-server (backend). 
+Initiating the sqlite-db overwrites any existing local db/bikr.db file you may already have upon container initialization.
 The database design is based on our first proper database modelling draft on https://miro.com/app/board/uXjVNUOg_Os=/.
 ```

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ docker-compose up -d server
 # (refreshes after updates)
 docker-compose up dev-server
 
-# start database (sqlite) in background
+# start database (sqlite)
 docker-compose up sqlite-db
 
 # shut down all containers
@@ -122,5 +122,5 @@ docker-compose up sqlite-db
 The database (bikr.db) is created when the sqlite-db container is initiated. Use the path ./db:/db" as a volume in docker-compose.yml
 to add the database in server or dev-server (backend). 
 Initiating the sqlite-db overwrites any existing local db/bikr.db file you may already have upon container initialization.
-The database design is based on our first proper database modelling draft on https://miro.com/app/board/uXjVNUOg_Os=/.
+The database design is based on our first proper database modelling draft on [Miro](https://miro.com/app/board/uXjVNUOg_Os=/).
 ```

--- a/db/setup.db.bash
+++ b/db/setup.db.bash
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
+
+DBFILE="bikr.db"
+
+# Remove any existing db named bikr.db
+if [[ -f $DBFILE ]]; then
+    rm -f bikr.db
+fi
+
+# Create and populate a new database named bikr.db
 touch bikr.db
 sqlite3 bikr.db < sql/setup.sql
-echo "SQlite setup script completed."
+
+# Check the exit status
+if [ $? -eq 0 ]; then
+    echo "setup.db.bash executed successfully."
+else
+    echo "setup.db.bash encountered an error."
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,19 +37,15 @@ services:
       - cyckelwebb
     restart: "always"
 
-  # database container, is reached through volume ./db:/db
-  # A database will be created from sql/
-  # start with docker compose up -d sqlite-db
+  # A database will be created from db/sql/setup.sql
+  # create db with: docker compose up sqlite-db
   sqlite-db:
     image: "eeemiiil/sqlite:1"
     container_name: "database"
     volumes:
       - "./db:/db"
     working_dir: /db
-    command: bash -c "./setup.db.bash && tail -f /dev/null"
-    networks:
-      - cyckelwebb
-    restart: "always"
+    command: bash -c "./setup.db.bash"
 
   # frontend app
   # webapp:


### PR DESCRIPTION
README: Simplified the description on how the sqlite-db container creates the db. 
Also removed some lines from docker-compose.yml under the sqlite-db service that was redundant. 
setup.db.bash is updated with more clear syntax, comments and better readability.